### PR TITLE
add a location obj

### DIFF
--- a/spec/readme.md
+++ b/spec/readme.md
@@ -28,6 +28,24 @@ You may also inline the `station` if that's more convenient:
 }
 ```
 
+## `location` objects
+
+A `location` object is used by other items to indicate their locations.
+
+```js
+{
+	type: 'location', // required
+	name: 'Reichstagsgebäude', // optional
+	address: 'Platz der Republik 1, 11011 Berlin', // optional
+
+	longitude: 13.4, // optional
+	latitude: 52.5, // optional
+	altitude: 1300 // optional
+}
+```
+
+If the `latitude` field is specified in a `location` object, the `longitude` field must also be specified, and vice-versa.
+
 ## item types
 
 ### `station`

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -58,11 +58,9 @@ A station is a larger building or area that can be identified by a name. It is u
 	id: '123456', // unique, url-safe, required
 	name: 'Berlin Hauptbahnhof', // official non-abbreviated name, required
 	// todo: other names
-	coordinates: { // optional
-		longitude: 52.5250839, // required
-		latitude: 13.3672133 // required
+	location: { // location object, optional
+		// … see above
 	},
-	address: 'Europaplatz 1, 10557 Berlin', // optional
 	regions: [ // region ids or region objects, see the section on 'region's, optional
 		'1234', '2345'
 	]
@@ -82,9 +80,8 @@ If the underlying data source does not allow such a fine-grained distinction, us
 	station: '123456', // station id or station object, required
 	name: 'Berlin Hauptbahnhof (tief)', // official non-abbreviated name, required
 	// todo: other names
-	coordinates: { // optional
-		longitude: 52.5250839, // required
-		latitude: 13.3672133 // required
+	location: { // location object, optional
+		// … see above
 	}
 }
 ```


### PR DESCRIPTION
This PR adds the `location` object we discussed in #19. Closes #19. Also indirectly closes #15.

----

https://github.com/public-transport/friendly-public-transport-format/blob/124a937f4954dcc3c62201918a6b75e927f9c11f/spec/readme.md#L61-L63

How should I format this? This would also work:

```js
location: { /* … */ } // location object, optional
```

----

https://github.com/public-transport/friendly-public-transport-format/blob/124a937f4954dcc3c62201918a6b75e927f9c11f/spec/readme.md#L198

This is still confusing. The proper, but too long and complex, description would be "station/stop object or id, or a location object". What do you think?